### PR TITLE
Bump UP_VERSION

### DIFF
--- a/makelib/k8s_tools.mk
+++ b/makelib/k8s_tools.mk
@@ -41,7 +41,7 @@ OLMBUNDLE_VERSION ?= v0.5.2
 OLMBUNDLE := $(TOOLS_HOST_DIR)/olm-bundle-$(OLMBUNDLE_VERSION)
 
 # the version of up to use
-UP_VERSION ?= v0.16.0
+UP_VERSION ?= v0.19.2
 UP_CHANNEL ?= stable
 UP := $(TOOLS_HOST_DIR)/up-$(UP_VERSION)
 


### PR DESCRIPTION
Consume new `up` CLI version required for build after package meta API version was bumped (e.g. https://github.com/upbound/provider-aws/pull/882).